### PR TITLE
[python] BJ2800 괄호제거

### DIFF
--- a/minwoo.lee/2021.08.21/BJ2800.py
+++ b/minwoo.lee/2021.08.21/BJ2800.py
@@ -1,3 +1,45 @@
 import sys
 
-a = sys.stdin.readline()
+
+class Solution:
+    def remove(self, start, element, answer, cnt, couple):
+        if cnt == 0:
+            me = math_expression[:]
+            for p1, p2 in element:
+                me[p1] = '';
+                me[p2] = ''
+            answer.append(''.join(me))
+            return
+
+        for i in range(start, len(couple)):
+            element.append(couple[i])
+            self.remove(i + 1, element, answer, cnt - 1, couple)
+            element.pop()
+
+    def solution(self, math_expression):
+        stack = []
+        couple = []
+        for idx, value in enumerate(math_expression):
+            if value == '(':
+                stack.append(idx)
+            elif value == ')':
+                i = stack.pop()
+                couple.append((i, idx))
+            else:
+                pass
+
+        answer = []
+        for cnt in range(1, len(couple) + 1):
+            self.remove(0, [], answer, cnt, couple)
+        answer = list(set(answer))
+        answer.sort()
+
+        for a in answer:
+            print(a)
+        return
+
+
+if __name__ == "__main__":
+    s = Solution()
+    math_expression = list(sys.stdin.readline().strip())
+    s.solution(math_expression)


### PR DESCRIPTION
## 접근 방법

수식 문자열 그대로를 바로 수정할 수 없기 때문에 문자열을 list로 받아준다.
수식에서 올바른 쌍의 여는 괄호 index와 닫는 괄호 index를 담는 리스트(couple)를 만들어 준다.

제거할 괄호 쌍의 개수는 1부터 전체 괄호쌍의 개수이므로 for 문을 1부터 시작해서 couple의 길이 +1 만큼 루프를 해준다.
재귀함수를 통해서 제거할 괄호 쌍 개수에 맞는 조합을 구해준다.
조합 값들에 대해 for문을 이용해 여는 괄호와 닫는 괄호의 index값의 문자열을 ''으로 바꿔준 후 result 리스트에 append해준다.
이때 append할 때 join을 통해 완성된 수식이 되도록한다.

마지막 result의 중복을 제거해주고 정렬을 해준 뒤 출력한다.