### PR TITLE
[python] BJ16954 풀이

### DIFF
--- a/minwoo.lee/2021.08.23/BJ16954.py
+++ b/minwoo.lee/2021.08.23/BJ16954.py
@@ -1,0 +1,44 @@
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+
+class Solution:
+    def __init__(self):
+        self.board = deque([list(input().strip()) for _ in range(8)])
+        self.walls = []
+        self.direction = [(0, 0), (0, 1), (1, 1), (1, 0), (1, -1), (0, -1), (-1, -1), (-1, 0), (-1, 1)]
+        for x in range(8):
+            for y in range(8):
+                if self.board[x][y] == '#':
+                    self.walls.append((x, y))
+        self.sx, self.sy = 7, 0
+        self.ex, self.ey = 0, 7
+
+    def solution(self):
+        if len(self.walls) == 0:
+            return 1
+
+        Q = deque([(self.sx, self.sy)])
+
+        while Q:
+            discovered = [[False] * 8 for _ in range(8)]
+            for _ in range(len(Q)):
+                x, y = Q.popleft()
+                if x == 0:
+                    return 1
+                if self.board[x][y] == '.':
+                    for dx, dy in self.direction:
+                        nx, ny = x + dx, y + dy
+                        if 0 <= nx < 8 and 0 <= ny < 8 and self.board[nx][ny] == '.' and not discovered[nx][ny]:
+                            discovered[nx][ny] = True
+                            Q.append((nx, ny))
+            self.board.pop()
+            self.board.appendleft(['.' for _ in range(8)])
+        return 0
+
+
+if __name__ == "__main__":
+    s = Solution()
+    print(s.solution())


### PR DESCRIPTION
## 문제 접근 방법

- 예전에 풀었던 풀이의 시간은 `1216ms` 였던걸 고려하여 시간을 단축할 방법에 대해 생각해보았다.

1. 미로 탈출의 조건은 `x` 와 `y`의 좌표가 문제에서 원하는 조건인 `(0,7)`이아닌 `x` 좌표가 `0`이기만 하면 가능하다로 생각을 바꾸었다.

> `x`의 좌표가 맨위에만 도달하면 더 이상의 벽은 존재하지 않기 때문이다.

2. 벽이 아래로 한 행씩 내려가는 것을 따로 함수를 이용해 하나하나씩 움직이지 않고 체스판을 나타내는 `board`의 마지막 행을 `pop` 하고 새로운 한 줄의 빈칸 `['.', '.', '.', '.', '.', '.', '.', '.', ]`을 맨 윗줄에 채우도록 하였다.

3. 체스판 `board` 의 경우 `list`로 선언하면 `pop` 은 쉬우나 맨 윗줄로의 삽입은 `O(n)`이기 때문에 `deque`를 이용하였다.

> `deque`의 경우 `appendleft`를 이용하면 `O(1)`에 해결할 수 있다.

- 이렇게 해서 새로 작성한 코드의 시간은 `96ms`로 많은 시간을 단축할 수 있었다.