### PR TITLE
[JAVA] BJ16954-움직이는 미로 탈출 문제 풀이

### DIFF
--- a/minwoo.seo/src/BJ16954.java
+++ b/minwoo.seo/src/BJ16954.java
@@ -1,0 +1,54 @@
+import java.io.*;
+import java.util.*;
+
+public class BJ16954 {
+  static boolean[][][] map;
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    map = new boolean[8][8][8];
+    // 시작 상태를 0번 인덱스에 저장
+    // 벽이 있으면 true, 벽이 없으면 false
+    for (int i = 0; i < 8; i++) {
+      String s = br.readLine();
+      for (int j = 0; j < 8; j++) {
+        char c = s.charAt(j);
+        if(c == '#') map[0][i][j] = true;
+      }
+    }
+    // 1~7초까지 각 초마다 벽이 어느 위치에 있을지 미리 만들어둠.
+    for (int time = 0; time < 8; time++) {
+      for (int i = 0; i < 7; i++) {
+        for (int j = 0; j < 8; j++) {
+          if(map[time][i][j]) {
+            map[time + 1][i + 1][j] = true;
+          }
+        }
+      }
+    }
+    System.out.println(sol());
+  }
+
+  static int[] dx = {0, -1, -1, 0, 1, 1, 1, 0, -1};
+  static int[] dy = {0, 0, 1, 1, 1, 0, -1, -1, -1};
+
+  private static int sol() {
+    Queue<int[]> queue = new LinkedList<>();
+    queue.add(new int[] {7, 0, 0});
+    while (!queue.isEmpty()) {
+      int[] cur = queue.poll();
+      int time = cur[2];
+      // 7초까지 살아있다면 더이상 위에 벽이 없음 -> 무조건 도착할 수 있음.
+      if(time+1 == 8) return 1;
+      for (int d = 0; d < 9; d++) {
+        int nx = cur[0] + dx[d];
+        int ny = cur[1] + dy[d];
+        // 8 * 8 체스판을 벗어나거나 현재 시간의 위치에 벽이 있거나 다음 시간에 벽이 있다면 다음 체크
+        if(nx < 0 || nx >= 8 || ny < 0 || ny >= 8
+            || map[time][nx][ny] || map[time+1][nx][ny]) continue;
+        // 현재 시간에도 이동할 수 있고 다음 시간에도 벽이 오지 않는다면
+        queue.add(new int[]{nx, ny, time+1});
+      }
+    }
+    return 0;
+  }
+}


### PR DESCRIPTION
7초 이상 캐릭터가 살아있다면 무조건 오른쪽 위에 도착할 수 있다는 생각에서 시작한 풀이입니다.

체스판의 크기가 크지 않고 시간 역시 많지 않기 때문에 각 초마다 벽이 어디에 위치하고 있는지 저장하고
* 체스판 밖을 나갈 때
* 현재 시간(초)에 벽이 있는 위치
* 다음 시간(초)에 벽이 있는 위치
는 이동하지 않고 7초까지 까지 살아있다면 더 이상 벽이 남아있지 않기 때문에 무조건 도착할 수 있어 `return 1` 
이외의 경우의 수는 도착할 수 없기 때문에 `return 0`

쉽게 풀었다 생각했는데 벽이 내려오는 구조에서 헛짓거리해서 계속된 실패가..