### PR TITLE
[JAVA] BJ19352-특정 거리의 도시 찾기 문제 풀이

### DIFF
--- a/minwoo.seo/src/BJ18352.java
+++ b/minwoo.seo/src/BJ18352.java
@@ -1,0 +1,76 @@
+import java.io.*;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class BJ18352 {
+
+  static class Node implements Comparable<Node>{
+    int vertex;
+    int weight;
+
+    public Node(int vertex, int weight) {
+      this.vertex = vertex;
+      this.weight = weight;
+    }
+
+    @Override
+    public int compareTo(Node o) {
+      return Integer.compare(this.weight, o.weight);
+    }
+  }
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st = new StringTokenizer(br.readLine());
+    int N = parse(st.nextToken());
+    int M = parse(st.nextToken());
+    int K = parse(st.nextToken());
+    int X = parse(st.nextToken());
+    // 인접 리스트
+    ArrayList<Node>[] adjList = new ArrayList[N+1];
+    for (int i = 0; i < N+1; i++) {
+      adjList[i] = new ArrayList<>();
+    }
+
+    for (int i = 0; i < M; i++) {
+      st = new StringTokenizer(br.readLine());
+      int start = parse(st.nextToken());
+      int end = parse(st.nextToken());
+      adjList[start].add(new Node(end, 1));
+    }
+
+    int[] dis = new int[N+1];
+    Arrays.fill(dis, 1000001);
+    dis[X] = 0;
+    PriorityQueue<Node> pq = new PriorityQueue<>();
+    pq.add(new Node(X, 0));
+    while (!pq.isEmpty()) {
+      Node cur = pq.poll();
+      int v = cur.vertex;
+      int w = cur.weight;
+
+      if(dis[v] < w) continue;
+
+      for (Node next: adjList[v]) {
+        int nextV = next.vertex;
+        int nextW = next.weight + w;
+        if(dis[nextV] > nextW) {
+          dis[nextV] = nextW;
+          pq.add(new Node(nextV, nextW));
+        }
+      }
+    }
+
+    boolean flag = true;
+    for (int i = 1; i < N+1; i++) {
+      if(dis[i] == K) {
+        System.out.println(i);
+        flag = false;
+      }
+    }
+    if(flag) System.out.println(-1);
+  }
+
+  private static int parse(String nextToken) {
+    return Integer.parseInt(nextToken);
+  }
+}


### PR DESCRIPTION
인접 행렬로 그래프를 만들었는데 해당 부분에서 메모리 초과가 발생 
 -> 단방향 그래프이고 도시의 개수는 30만개로 최대 나올 수 있는 도로의 수는 `300000 * (300000-1) /2 = 44,999,850,000` 개인데 문제에서 제공하는 도로의 개수는 1,000,000개 밖에 없어서 메모리 초과가 발생하는 것을 보임.

따라서 인접 리스트를 이용해서 해결해야 하는 다익스트라 문제.
 