### PR TITLE
[Java]BJ22860-폴더 정리(small) 문제 풀이

### DIFF
--- a/minwoo.seo/src/BJ22860.java
+++ b/minwoo.seo/src/BJ22860.java
@@ -1,0 +1,93 @@
+import java.io.*;
+import java.util.*;
+
+public class BJ22860 {
+    static ArrayList<Folder> folders = new ArrayList<>();
+    static HashMap<String, Integer> folderIndex = new HashMap<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken()); // 폴더의 총 개수
+        int M = Integer.parseInt(st.nextToken()); // 파일의 총 개수
+
+        int idx = 0;
+        folders.add(new Folder("main"));
+        folderIndex.put("main", idx++);
+
+        ArrayList<String[]> temp = new ArrayList<>();
+        for (int i = 0; i < N + M; i++) {
+            st = new StringTokenizer(br.readLine());
+            String upper = st.nextToken();
+            String now = st.nextToken();
+            String check = st.nextToken();
+            // boolean isFolder = Integer.parseInt(st.nextToken()) == 1;
+
+            //if(isFolder) { // 폴더라면
+                folders.add(new Folder(now));
+                folderIndex.put(now, idx++);
+                temp.add(new String[] {upper, now, check});
+               // folders.get(folderIndex.get(upper)).addSubFolder(now);
+            //}
+            //else { // 파일이라면
+               // folders.get(folderIndex.get(upper)).addFile(now);
+            //}
+        }
+        for (String[] cur : temp) {
+            if(Integer.parseInt(cur[2]) == 1) {
+                folders.get(folderIndex.get(cur[0])).addSubFolder(cur[1]);
+            } else {
+                folders.get(folderIndex.get(cur[0])).addFile(cur[1]);
+            }
+        }
+        int Q = Integer.parseInt(br.readLine());
+        for (int i = 0; i < Q; i++) {
+            String[] query = br.readLine().split("/");
+            allFiles = new HashSet<>();
+            fileCnt = 0;
+            dfs(folders.get(folderIndex.get(query[query.length - 1]))); // 마지막에 위치한 폴더
+            bw.write(allFiles.size() + " " + fileCnt + "\n");
+
+        }
+        bw.flush();
+        bw.close();
+        br.close();
+
+    }
+    static HashSet<String> allFiles;
+    static int fileCnt;
+    private static void dfs(Folder folder) {
+
+        // 파일 추가
+        for (String file : folder.files) {
+            allFiles.add(file);
+            fileCnt++;
+        }
+
+        // 현재 폴더에서 하위폴더로 재귀
+        for (String sub: folder.subs) {
+            dfs(folders.get(folderIndex.get(sub)));
+        }
+    }
+
+    static class Folder {
+        String name;
+        List<String> files;
+        List<String> subs;
+
+        public Folder(String name) {
+            this.name = name;
+            files = new ArrayList<>();
+            subs = new ArrayList<>();
+        }
+        public void addFile(String file) {
+            files.add(file);
+        }
+
+        public void addSubFolder(String folder) {
+            subs.add(folder);
+        }
+    }
+}


### PR DESCRIPTION
생각보다 많이 어려웠던 문제였습니다.
트리를 구성하고 해시셋을 이용해서 중복되는 파일의 이름을 체크해야합니다. 
어려웠던 부분은 입력을 받으면서 폴더와 파일의 트리를 구성하려 했으나 `NullPointerError` 가 발생하는 걸로 봐서는 입력되는 폴더의 구성 문자열이 위에서부터 차근차근 올라오는 것이 아니라 무작위로 되어있는 듯 합니다. 그래서 해당 부분에 대한 추가 검증이 필요했습니다.

### 초기화
먼저, 폴더라는 클래스를 정의하여 폴더의 이름, 하위 폴더, 하위 파일을 저장하였습니다.
그리고 입력되는 모든 폴더는 리스트에 저장하였고 폴더의 이름만 보고 리스트에 접근하기 쉽도록 폴더의 이름과 리스트의 인덱스를 갖는 Map(dict)을 추가로 만들어 저장하였습니다. 

### 폴더 트리 구성
38라인부터 구성되는 폴더 트리 구성은 입력되는 문자열을 미리 저장해두고 상위 폴더에 하위 폴더의 이름을 추가하는 형식입니다. 만약 파일이라면 해당 폴더에 파일의 이름을 추가하였습니다.

### 쿼리 진행
각 쿼리는 `/` 로 구분되어있고 쿼리로 시작되는 폴더부터 모든 하위 폴더를 탐색하기 때문에 가장 마지막에 위치한 폴더부터 DFS를 진행하였습니다.
각 쿼리마다 Set을 이용하여 같은 이름을 갖는 파일을 정리했으며 다른 폴더에 있는 같은 이름의 파일 역시 카운트는 해야하기에 모든 파일을 카운트하는 변수 또한 추가하였습니다.

resolves #35 