### PR TITLE
[python] BJ22860-폴더 정리(small) 문제풀이

### DIFF
--- a/minwoo.lee/2021.09.05/BJ22860.py
+++ b/minwoo.lee/2021.09.05/BJ22860.py
@@ -1,0 +1,30 @@
+import sys
+from collections import defaultdict, deque
+
+input = sys.stdin.readline
+
+
+def solution():
+    q = int(input().strip())
+    for _ in range(q):
+        kind, count = set(), 0
+        query = input().strip().split('/')[-1]
+        Q = deque([query])
+        while Q:
+            folder = Q.popleft()
+            for f, value in tree[folder]:
+                if value == '0':
+                    count += 1
+                    kind.add(f)
+                else:
+                    Q.append(f)
+
+        print(len(kind), count)
+
+
+n, m = map(int, input().split())
+tree = defaultdict(list)
+for _ in range(n + m):
+    p, f, c = input().split()
+    tree[p].append((f, c))
+solution()


### PR DESCRIPTION
## 문제 접근 방법

- 폴더의 구조를 만들어 주기 위해서 트리를 만들어야겠다고 생각했다.
- 트리는 `key` 값으로 부모 `value`로 리스트 리스트 안의 값은 (자식,  폴더(파일)인지 나타내는 값)인 형태로 만들어 주었다.
- 쿼리를 받으면 맨 뒤 값을 가져온다. 
> 쿼리로 온 폴더 경로 중 맨 뒤 폴더 부터 탐색을 진행하면 되기 때문이다.


- 해당 폴더를 `Q`에 넣어주고 탐색을 진행하며 파일인 경우 `count`를 1 더해주고 해당 파일의 값을  `set`자료형인 `kind`에 넣어준다.
> `set`의 경우 중복처리를 할 수 있기에 같은 폴더 이름을 추가해도 추가되지 않는다.
- 폴더인경우 `Q`에 넣어주어 다음 폴더에 있는 값 들을 탐색할 수 있게 한다.



- 최종적으로 탐색이 끝났다면 `kind`의 길이와 `count`값을 출력

시간은 `400ms`로 `python3`로 푼 사람이 나를 포함 3명밖에 없지만 1등인 것을 확인했다.