### PR TITLE
[Java]BJ1194 - 달이 차오른다, 가자. 문제풀이

### DIFF
--- a/minwoo.seo/src/BJ1194.java
+++ b/minwoo.seo/src/BJ1194.java
@@ -1,0 +1,80 @@
+import java.util.*;
+
+public class BJ1194 {
+    static int N, M;
+    static char[][] map;
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        N = sc.nextInt(); // 세로
+        M = sc.nextInt(); // 가로
+
+        map = new char[N][M];
+        int[] start = new int[4];
+        for (int i = 0; i < N; i++) {
+            String s = sc.next();
+            for (int j = 0; j < M; j++) {
+                map[i][j] = s.charAt(j);
+                if(map[i][j] == '0'){
+                    start = new int[]{i, j, 0, 0}; // 출발 위치, 이동한 거리, 갖고있는 키 개수
+                    map[i][j] = '.';
+                }
+            }
+        }
+        // 방문 배열이 각 칸마다 64인 이유는 열쇠/문의 개수가 a~f로 6개이기 때문
+        boolean[][][] visited = new boolean[N][M][64];
+        Queue<int[]> queue = new LinkedList<>();
+
+        queue.add(start);
+        visited[start[0]][start[1]][0] = true;
+        // bfs
+        while (!queue.isEmpty()) {
+            int[] cur = queue.poll();
+            int x = cur[0];
+            int y = cur[1];
+            int dis = cur[2];
+            int key = cur[3];
+
+            for (int d = 0; d < 4; d++) {
+                int nx = x + dx[d];
+                int ny = y + dy[d];
+                if(nx < 0 || nx >= N || ny < 0 || ny>=M || visited[nx][ny][key] || map[nx][ny] =='#') continue;
+                if(map[nx][ny] == '.') {
+                    visited[nx][ny][key] = true;
+                    queue.add(new int[]{nx, ny, dis+1, key});
+                }
+                else if(map[nx][ny] >= 'a' && map[nx][ny] <='f') {
+                    int newKey = addKey(key, map[nx][ny]);
+                    visited[nx][ny][newKey] = true;
+                    queue.add(new int[] {nx,ny, dis+1, newKey});
+                }
+                else if(map[nx][ny] >= 'A' && map[nx][ny] <= 'F') {
+                    if(hasKey(key, map[nx][ny])) {
+                        visited[nx][ny][key] = true;
+                        queue.add(new int[]{nx,ny, dis+1, key});
+                    }
+                }
+                else if(map[nx][ny] == '1') {
+                    System.out.println(dis+1);
+                    return;
+                }
+            }
+        }
+        System.out.println(-1);
+    }
+
+    private static boolean hasKey(int key, char cKey) {
+        int k = cKey - 'A';
+        return (key & (1 << k)) != 0;
+
+    }
+
+    private static int addKey(int key, char cKey) {
+        int k = cKey - 'a';
+        key = key | (1 << k);
+        return key;
+    }
+
+    static int[] dx = {-1, 0, 1, 0};
+    static int[] dy = {0, 1, 0, -1};
+}


### PR DESCRIPTION
비트마스킹을 활용한 bfs 문제입니다.

비트마스킹을 제외하고는 사실 탐색에 있어 크게 신경써야할 부분은 없다고 생각할 수 있습니다.
그만큼 비트마스킹이 어려운 영역으로 쉽게 생각해내기 좀 어려운 느낌입니다. (이번 카카오 5번 양과 늑대문제마냥)
a~f 키를 각각 들고있는 것을 확인하기 위해 1을 비트 이동 연산과 |(OR) 연산, &(AND) 연산을 이용하여 키 추가, 키 확인을 해야합니다.

* 키 추가(ADD)
  현재 상태에서 들고있는 key 에 |(OR) 연산을 이용하여 a\~f(0\~5) 키의 비트 이동을 시켜 마킹을 해줍니다.
  새로운 키를 추가하여 탐색을 진행합니다.
 키를 주웠을 때 2차원 배열에서 없애버리지 않는 이유는 같은 자리에 가더라도 이미 키를 갖고 있는 상태이기에 그 위치는 계속해서 지나갈 수 있는 위치입니다. 즉, 없애든 말든 상관이 없는 것입니다. 
또한, 키의 개수에 맞게 방문 배열의 길이를 설정했기 때문에 다른 상태에게도 키를 주울 수 있게 만들어야합니다.
* 키 확인(hasKey)
  현재 상태에서 키를 들고 있는지 확인하는 &(AND) 연산을 이용해서 키가 해당하는 비트에 키가 있는지, 즉 1이 있는지 확인해서
  * 키가 있다면 문을 열고 지나가서 계속 탐색을 진행하고
  * 없다면 지나가지 못합니다.