### PR TITLE
[python] BJ17471-게리맨더링 문제풀이

### DIFF
--- a/minwoo.lee/2021.09.15/BJ17471.py
+++ b/minwoo.lee/2021.09.15/BJ17471.py
@@ -1,0 +1,47 @@
+import sys
+from itertools import combinations
+from collections import deque
+
+input = sys.stdin.readline
+
+
+def get_sum(group):
+    # 해당 선거구 내의 구역 모두 모두 이어져있다면 어디서 시작하든지 상관없으므로 첫번째 값을 시작 값으로 잡는다.
+    start = group[0]
+    Q = deque([start])
+    discovered = [start]
+    sum_population = 0
+    while Q:
+        area = Q.popleft()
+        sum_population += populations[area]
+        for next in graph[area]:
+            if next not in discovered and next in group:
+                Q.append(next)
+                discovered.append(next)
+    return sum_population, len(discovered)
+
+
+def solution():
+    result = float('inf')
+    n_list = [i for i in range(1, n + 1)]
+
+    for i in range(1, n // 2 + 1):
+        combi_list = list(combinations(n_list, i))
+        for combi in combi_list:
+            s1, l1 = get_sum(combi)
+            s2, l2 = get_sum([i for i in range(1, n + 1) if i not in combi])
+            if l1 + l2 == n:
+                result = min(result, abs(s1 - s2))
+
+    return result if result != float('inf') else -1
+
+
+n = int(input().strip())
+populations = dict()
+for idx, p in zip([i for i in range(1, n + 1)], list(map(int, input().split()))):
+    populations[idx] = p
+graph = dict()
+for idx in range(1, n + 1):
+    cnt, *adj = list(map(int, input().split()))
+    graph[idx] = adj
+print(solution())


### PR DESCRIPTION
## 문제 접근 방법

- 먼저 각 구역의 번호가 1부터 시작하므로 `list`로 표현하면 `index`값을 `-1`씩 해줘야하는데 나중에 혼동될까봐 `dict`로 구역의 인구수를 표현하도록 하였다.
- `graph` 역시 `dict`로 만들어 각 구역 번호를 `key`로 `value`값을 인접한 구역을 리스트로 저장하였다.
- 임의의 두 구역으로 나누어야하는데 조합을 통해 두 선거구로 나누도록 하였다.

> 이 때 `n//2`만큼만 조합의 개수를 구해 중복이 일어나지 않도록 한다는 아이디어를 `java`풀이에서 힌트를 얻었다.

- 첫번째 선거구가 정해지면 `BFS`에 인자로 넘겨 해당 구가 연결되어 있는지 확인하는데 이 때 인자로 넘겨준 `group`에 포함되는지 확인하여 속하는 영역의 인구수와 `discovered`의 길이를 구한다
- 두번째 선거구는 기존의 전체 리스트에서 선거구만큼 제외시키고 `BFS`를 진행한다.
- 첫번째 선거구의 탐색된 길이와 두번째 선거구의 탐색된 길이가 전체 `n`과 같다면 각 선거구가 이어져있는 것이기 때문에
`s1,s2` 값의 차를 절대값으로 구해 `result`에 `min`함수를 이용하여 최솟값을 가지도록 한다.
- 만약 `result` 값이 여전히 무한대값을 가지면 선거구를 나누지 못하는 것이므로 -1 그렇지 않으면 구해진 `result` 값을 출력한다.