### PR TITLE
[JAVA] BJ17609 - 회문 문제풀이

### DIFF
--- a/minwoo.lee_java/src/BOJ17609.java
+++ b/minwoo.lee_java/src/BOJ17609.java
@@ -1,0 +1,32 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class BOJ17609 {
+    public static int palindrome(char[] arr, int start, int end, int cnt) {
+        if (cnt >= 2) {
+            return cnt;
+        }
+        while (start <= end) {
+            if (arr[start] == arr[end]) {
+                start++;
+                end--;
+            } else {
+                cnt = Math.min(palindrome(arr, start + 1, end, cnt + 1), palindrome(arr, start, end - 1, cnt + 1));
+                return cnt;
+            }
+        }
+        return cnt;
+    }
+
+    public static void main(String args[]) throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(bf.readLine());
+        int result = 0;
+        for (int i = 0; i < T; i++) {
+            char[] arr = bf.readLine().toCharArray();
+            result = palindrome(arr, 0, arr.length - 1, 0);
+            System.out.println(result);
+        }
+    }
+}


### PR DESCRIPTION
`palindrome` 함수에서 `p1`은 `0` `p2`는 배열의 마지막 인덱스로 시작하여
인덱스에 해당하는 문자가 일치하면 `p1`은 1증가 `p2`는 1감소하면서 진행한다.
아무런 문제없이 `while`문이 끝날때까지 진행된다면 이는 전체가 `palindrome`이므로 0을 출력한다.

그렇다면 중간에 서로 다른 문자가 나왔을때 어떻게 처리할지를 고민했다.
두 문자가 다른 경우가 발생했을때 `p1`을 증가하여 확인하는 경우와 `p2`를 감소시켜 진행한 두 경우를 재귀를 통해 각각 확인하였다.
물론 재귀의 깊이가 곧 없앤 문자의 수이므로 재귀의 깊이가 `2`이상이 되면 `2`를리턴하도록 하였고 각 `return`된 값 중 더 작은 값이 곧 답이된다.
다행히 실행속도도 준수하게 나왔다. `348ms`