### PR TITLE
[백준] 17141. 연구소2 문제풀이

### DIFF
--- a/minwoo.lee_java/src/BOJ17141.java
+++ b/minwoo.lee_java/src/BOJ17141.java
@@ -37,7 +37,7 @@ public class BOJ17141 {
             System.out.println(-1);
     }
 
-    static void getCombine(int start, int cnt, Stack candi) {
+    static void getCombine(int start, int cnt, Stack<Integer> candi) {
         if (cnt == M) {
             BFS(candi);
             return;
@@ -49,11 +49,11 @@ public class BOJ17141 {
         }
     }
 
-    static void BFS(Stack candidate) {
+    static void BFS(Stack<Integer> candidate) {
         boolean[][] discovered = new boolean[N][N];
         Queue<Location> queue = new LinkedList<>();
         for (int i = 0; i < M; i++) {
-            Location virus = locations.get((Integer)candidate.get(i));
+            Location virus = locations.get((Integer) candidate.get(i));
             discovered[virus.x][virus.y] = true;
             queue.add(virus);
         }
@@ -89,7 +89,7 @@ public class BOJ17141 {
             result = Math.min(result, value);
     }
 
-    static class Location implements Cloneable {
+    static class Location {
         int x, y, time;
 
         Location(int x, int y, int time) {

--- a/minwoo.lee_java/src/BOJ17141.java
+++ b/minwoo.lee_java/src/BOJ17141.java
@@ -1,0 +1,101 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ17141 {
+    static int N, M, zeroCnt, result;
+    static int[][] arr;
+    static int[][] direction = {{0, 1}, {1, 0}, {0, -1}, {-1, 0}};
+    static ArrayList<Location> locations = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(bf.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+
+        result = Integer.MAX_VALUE;
+        arr = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(bf.readLine());
+            for (int j = 0; j < N; j++) {
+                arr[i][j] = Integer.parseInt(st.nextToken());
+                if (arr[i][j] == 2) {
+                    locations.add(new Location(i, j, 0));
+                    arr[i][j] = 0;
+                    zeroCnt++;
+                    continue;
+                }
+                if (arr[i][j] == 0)
+                    zeroCnt++;
+            }
+        }
+        getCombine(0, 0, new Stack<Integer>());
+        if (result != Integer.MAX_VALUE)
+            System.out.println(result);
+        else
+            System.out.println(-1);
+    }
+
+    static void getCombine(int start, int cnt, Stack candi) {
+        if (cnt == M) {
+            BFS(candi);
+            return;
+        }
+        for (int idx = start; idx < locations.size(); idx++) {
+            candi.push(idx);
+            getCombine(idx + 1, cnt + 1, candi);
+            candi.pop();
+        }
+    }
+
+    static void BFS(Stack candidate) {
+        boolean[][] discovered = new boolean[N][N];
+        Queue<Location> queue = new LinkedList<>();
+        for (int i = 0; i < M; i++) {
+            Location virus = locations.get((Integer)candidate.get(i));
+            discovered[virus.x][virus.y] = true;
+            queue.add(virus);
+        }
+
+        int value = 0, virusCnt = M;
+
+        LinkedList<Location> next = new LinkedList<>();
+        int nx, ny;
+
+        while (!queue.isEmpty()) {
+            Location virus = queue.poll();
+            if (virus.time > result) return;
+            for (int d = 0; d < 4; d++) {
+                nx = virus.x + direction[d][0];
+                ny = virus.y + direction[d][1];
+                if (0 <= nx && nx < N && 0 <= ny && ny < N && !discovered[nx][ny]) {
+                    if (arr[nx][ny] == 0) {
+                        discovered[nx][ny] = true;
+                        virusCnt++;
+                        value = virus.time + 1;
+                        next.add(new Location(nx, ny, virus.time + 1));
+
+                    }
+                }
+            }
+            if (queue.isEmpty()) {
+                queue = next;
+                next = new LinkedList<>();
+            }
+
+        }
+        if (virusCnt == zeroCnt)
+            result = Math.min(result, value);
+    }
+
+    static class Location implements Cloneable {
+        int x, y, time;
+
+        Location(int x, int y, int time) {
+            this.x = x;
+            this.y = y;
+            this.time = time;
+        }
+    }
+}


### PR DESCRIPTION
바이러스 `arr[i][j]`값이 2인 부분들은 `Location` 클래스를 이용하여 객체로 만든후 `locations`에 담아줍니다.
그리고 그 좌표들은 모두 `0`으로 만들어줍니다. 왜냐하면 특정 좌표에만 연구소가 설치되므로 그 구역은
`0`이 되기 때문입니다.

그 다음 바이러스 위치들로 만들 수 있는 조합을 구하여 그 조합으로 만들어진 값들을 `BFS`를 통해
연구소 전체로 퍼지는지 확인하고 퍼진다면 걸린 시간 값들중 최소값을 구해줍니다.

`BFS`탐색을 하기전에 연구소 조합들의 좌표값들은 미리 방문처리를 해두고 탐색을 시작합니다.
각 연구소 좌표로 부터 동시에 바이러스가 퍼지기 때문에 다음좌표들은 `next`에 담아두었다가
`queue`가 비어지게 되면 담아줍니다.

`BFS`과정 중에서 바이러스가 퍼지는 시간이 기존에 걸렸던 값보다 큰 경우에는 더이상 탐색을 안해도 되므로 `if (virus.time > result) return;`를 사용하여 시간을 줄일 수 있도록하였습니다.

바이러스가 전체로 퍼졌는지 확인하는 방법은 `zeroCnt` `0`의 개수(연구소 포함)
`virusCnt` 초기 값은 `M`입니다. 그리고 탐색하면서 `0`을 만나면 `1`씩 더해줍니다.
이 두값이 같으면 전체로 바이러스가 퍼진걸로 확인할 수 있습니다.