### PR TITLE
[백준] 22944. 죽음의 비 문제 풀이

### DIFF
--- a/minwoo.lee_java/src/BOJ22944.java
+++ b/minwoo.lee_java/src/BOJ22944.java
@@ -1,0 +1,68 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ22944 {
+    static int N, H, D, endX, endY, result;
+    static char[][] map;
+    static ArrayList<int[]> umbrella;
+    static boolean[] discovered;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        H = Integer.parseInt(st.nextToken());
+        D = Integer.parseInt(st.nextToken());
+        map = new char[N][N];
+        umbrella = new ArrayList();
+        int startX = 0, startY = 0;
+        for (int i = 0; i < N; i++) {
+            int j = 0;
+            for (char v : br.readLine().toCharArray()) {
+                map[i][j] = v;
+                if (v == 'S') {
+                    startX = i;
+                    startY = j;
+                } else if (v == 'E') {
+                    endX = i;
+                    endY = j;
+                } else if (v == 'U') {
+                    umbrella.add(new int[]{i, j});
+                }
+                j++;
+            }
+        }
+        result = Integer.MAX_VALUE;
+        discovered = new boolean[umbrella.size()];
+        getShortestDistance(startX, startY, H, 0, 0);
+        if (result == Integer.MAX_VALUE) {
+            System.out.println(-1);
+        } else {
+            System.out.println(result);
+        }
+
+    }
+
+    private static void getShortestDistance(int x, int y, int hp, int durability, int distance) {
+
+        if (hp + durability >= Math.abs(x - endX) + Math.abs(y - endY)) {
+            result = Math.min(result, distance + Math.abs(x - endX) + Math.abs(y - endY));
+            return;
+        }
+        for (int i = 0; i < umbrella.size(); i++) {
+            int umbDis = Math.abs(x - umbrella.get(i)[0]) + Math.abs(y - umbrella.get(i)[1]);
+            if (discovered[i] || hp + durability <= umbDis - 1) {
+                continue;
+            }
+            if (durability >= umbDis - 1) {
+                discovered[i] = true;
+                getShortestDistance(umbrella.get(i)[0], umbrella.get(i)[1], hp, D - 1, distance + umbDis);
+                discovered[i] = false;
+            } else {
+                discovered[i] = true;
+                getShortestDistance(umbrella.get(i)[0], umbrella.get(i)[1], hp - (umbDis - durability) + 1, D - 1, distance + umbDis);
+                discovered[i] = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
많이 틀리고 시간초과도 많이 뜨고 여러 방식을 생각하면서 문제를 풀어보았습니다.
처음엔 `BFS`를 사용하여 문제를 해결하였습니다. 하지만 굳이 한칸씩 한칸씩 탐색을 할 필요가 있을까?라는 의문이 남았습니다.
그래서 재귀를 이용하여 문제를 다시 풀어보았습니다.
해당 코드의 아이디어는 다음과 같습니다.
시작점 `S` 도착점 `E` 그리고 우산의 좌표들 `U1` `U2` `U3` 가 있다고 하겠습니다.
1. 시작 점에서 도착점까지 우산이 필요없이 갈 수 있으면 바로 값을 출력합니다.
2. 우산이 있는 장소를 방문 후에 도착점에 도착한 경우는 시작점에서 우산까지 최단거리로 갔고 그 우산의 위치에서 도착점까지 최단거리로 갔다라는 말과 같게 됩니다.
3. 그렇다면 우산이 있는 곳을 방문한 경우의 수는 `S - U1 -  E`, `S - U1 -  U2 - E`, `S - U1 -  U2 - U3 - E` ... `S - U3 -  U2 - U1 - E`이 됩니다.
4. 즉 우산의 좌표 `K`개가 있을 때 `kP1` ~ `kPk`까지의 순열을 구해보면서 우산이 있는 곳을 방문했을 때 그 지점에서 도착점까지
갈 수 있다면 거리를 구하고 기존의 경로보다 짧다면 값을 갱신해 줍니다.