### PR TITLE
[백준] 14567. 선수과목 문제풀이

### DIFF
--- a/minwoo.seo/src/BJ14567.java
+++ b/minwoo.seo/src/BJ14567.java
@@ -1,0 +1,43 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BJ14567 {
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st = new StringTokenizer(br.readLine());
+    int N = parse(st.nextToken());
+    int M = parse(st.nextToken());
+
+    // 인접리스트
+    ArrayList<Integer>[] parents = new ArrayList[N + 1];
+    for (int i = 1; i < N + 1; i++) {
+      parents[i] = new ArrayList<>();
+    }
+
+    for (int i = 0; i < M; i++) {
+      st = new StringTokenizer(br.readLine());
+      int start = parse(st.nextToken());
+      int end = parse(st.nextToken());
+
+      parents[end].add(start); // start -> end 의 형태에서 end 로 오는 값들을 리스트에 저장
+    }
+
+    int[] dp = new int[N + 1];
+    Arrays.fill(dp, 1); // 기본 세팅
+
+    for (int i = 1; i < N + 1; i++) {
+      for (int k : parents[i]) {
+        dp[i] = Math.max(dp[i], dp[k] + 1);
+      }
+      System.out.print(dp[i] + " ");
+    }
+  }
+
+  private static int parse(String num) {
+    return Integer.parseInt(num);
+  }
+}


### PR DESCRIPTION
처음봤을때 위상정렬로 풀어야하는 문제처럼 느껴졌지만 
그래프나 정렬에는 약하기 때문에.. dp 스럽게 풀었습니다.

문제에서 제공하는 N<=1000,  M <= 500000 이므로 제한 시간 5초 이내에 실행이 될 수 있을 것으로 보입니다.

인접리스트는 부모의 기준에서 어떤 자식들이 연결되는지 확인하기 위해 리스트의 배열형태로 만들었습니다.
dp 배열은 초기화 때 모든 강의는 1학기때 들을 수 있다고 가정하고 초기화를 했습니다.

로직의 경우 간단합니다.
1부터 하나의 노드씩 돌면서 자식의 값들 중 큰값 + 1 을 가져와서 비교합니다.

이 방법이 가능한 이유는 아래와 같은 조건이 있기 때문입니다.
> A<B인 입력만 주어진다. (1≤A<B≤N)
