### PR TITLE
[백준] 14567. 선수과목 문제풀이

### DIFF
--- a/minwoo.lee_java/src/BOJ14567.java
+++ b/minwoo.lee_java/src/BOJ14567.java
@@ -1,0 +1,58 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ14567 {
+    static int[] preRequestCnt, result;
+    static int[][] graph;
+    static int N, M;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        // 진입 차수를 뜻하는 배열
+        // ex 값이 1 3 / 2 3 존재한다 가정하면
+        // 3은 1에서 진입할 수 있고 2에서 진입할 수 있기 때문에 preRequestCnt[3] = 2가된다.
+        preRequestCnt = new int[N + 1];
+        result = new int[N + 1];
+        graph = new int[N + 1][N + 1];
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int first = Integer.parseInt(st.nextToken());
+            int next = Integer.parseInt(st.nextToken());
+            graph[first][next] = 1;
+            preRequestCnt[next]++;
+        }
+        topologicalSort();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= N; i++) {
+            sb.append(result[i] + " ");
+        }
+        System.out.println(sb);
+    }
+
+    private static void topologicalSort() {
+        Queue<Integer> queue = new LinkedList<>();
+        // 진입 차수가 0인 노드 즉 선수과목이 없는 노드를 큐에 삽입
+        for (int i = 1; i <= N; i++) {
+            if (preRequestCnt[i] == 0) {
+                queue.add(i);
+            }
+        }
+        int cnt = 1;
+        while (!queue.isEmpty()) {
+            int size = queue.size();
+            for (int i = 0; i < size; i++) {
+                int subject = queue.poll();
+                result[subject] = cnt;
+                for (int j = 1; j < graph[subject].length; j++) {
+                    if (graph[subject][j] == 1 && --preRequestCnt[j] == 0) {
+                        queue.add(j);
+                    }
+                }
+            }
+            cnt++;
+        }
+    }
+}


### PR DESCRIPTION
방향 그래프이고 선수과목을 이수해야 다음 과목을 이수 할 수 있으므로 즉 과목을 듣는 순서를 찾아야 한다라고 판단하여
위상정렬을 응용하여 풀어야겠다고 생각했습니다.
`preRequestCnt`는 진입 차수를 뜻하는 배열로 문제에서 `M`개의 줄에 걸쳐 선수과목 조건이 주어지는데
1. `A` `B`가 주어지면 `preRequestCnt[B]`의 카운트를 증가시켜줍니다.
2. 진입 차수가 0인 과목 즉 선수과목이 없는 과목을 큐에 삽입하여 줍니다.
3. 큐에서 값을 꺼내어 `subject` 라는 변수에 담아주고 이를 `result`의 배열의 `index`로 하여 몇 학기에 이수할지 있을지를 나타내는 `cnt`값을 저장해줍니다.
4. `subject`와 연결된 과목의 `preRequestCnt`를 1 감소시킵니다.
5. 이 때 `preRequestCnt`가 0이면 선수 과목을 모두 들은 것으로 생각할 수 있으므로 큐에넣어주고 큐가 빌때까지 반복하여줍니다.
