### PR TITLE
[백준] 1717. 집합의 표현 문제풀이

### DIFF
--- a/minwoo.lee_java/src/BOJ1717.java
+++ b/minwoo.lee_java/src/BOJ1717.java
@@ -1,0 +1,63 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ1717 {
+    static int[] parent;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        makeSet(n);
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int op = Integer.parseInt(st.nextToken());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            if (op == 0) {
+                if (a != b) {
+                    union(a, b);
+                }
+            } else {
+                String result = (a == b) ? "YES" : isSameParent(a, b);
+                sb.append(result + "\n");
+            }
+        }
+        System.out.print(sb);
+    }
+
+    private static void makeSet(int n) {
+        parent = new int[n + 1];
+        for (int i = 1; i <= n; i++) {
+            parent[i] = i;
+        }
+    }
+
+    private static void union(int a, int b) {
+        a = find(a);
+        b = find(b);
+        if (a < b) {
+            parent[b] = a;
+        } else {
+            parent[a] = b;
+        }
+    }
+
+    private static int find(int element) {
+        if (parent[element] == element) {
+            return element;
+        }
+        return find(parent[element]);
+    }
+
+    private static String isSameParent(int a, int b) {
+        a = find(a);
+        b = find(b);
+        if (a == b) {
+            return "YES";
+        }
+        return "NO";
+    }
+}


### PR DESCRIPTION
예전에 `MST`를 공부하면서 알게되었던 `Union` `Find`를 이용하여 문제를 풀면 되겠다는 아이디어를 떠올렸습니다.
`makeSet`함수는 처음에 원소가 각각 집합을 이루고 있다는 걸 표현합니다. 이 때 자기 자신을
부모로 하는 배열을 만들어줍니다.
`Union` 함수는 두 집합을 합치는 메소드입니다. 부모가 다른 경우 부모의 값이 작은 쪽으로 합쳐줍니다.
`Find`는 원소의 부모를 찾는 메소드인데 이 때 두 원소의 부모가 같다면 같은 집합임을 알 수 있습니다.
문제에서 `a`와 `b`는 같을 수 있다하여 같은 경우는 따로 메소드를 호출하지 않고 `YES`를 호출하도록 하였습니다.