### PR TITLE
[백준] 17070. 파이프 옮기기1 문제풀이

### DIFF
--- a/minwoo.lee_java/src/BOJ17070.java
+++ b/minwoo.lee_java/src/BOJ17070.java
@@ -1,0 +1,39 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ17070 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        int N = Integer.parseInt(br.readLine());
+        int[][] map = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        int[][][] dp = new int[N][N][3];
+        dp[0][1][0] = 1;
+        for (int j = 2; j < N; j++) {
+            if (map[0][j] == 0) {
+                dp[0][j][0] = dp[0][j - 1][0];
+            }
+        }
+        for (int i = 1; i < N; i++) {
+            for (int j = 2; j < N; j++) {
+                // 대각선
+                if (map[i][j] == 0 && map[i - 1][j] == 0 && map[i][j - 1] == 0) {
+                    dp[i][j][2] = Math.max(dp[i][j][2], dp[i - 1][j - 1][0] + dp[i - 1][j - 1][1] + dp[i - 1][j - 1][2]);
+                }
+                if (map[i][j] == 0) {
+                    // 가로
+                    dp[i][j][0] = Math.max(dp[i][j][0], dp[i][j - 1][0] + dp[i][j - 1][2]);
+                    // 세로
+                    dp[i][j][1] = Math.max(dp[i][j][1], dp[i - 1][j][1] + dp[i - 1][j][2]);
+                }
+            }
+        }
+        System.out.println((dp[N - 1][N - 1][0] + dp[N - 1][N - 1][1] + dp[N - 1][N - 1][2]));
+    }
+}


### PR DESCRIPTION
문제에서 요구하는 `(N,N)`으로 이동하는 방법의 수는 대각선, 세로, 가로 3가지 방향으로 도착하였을 때의 누적합이라
판단하여 `dp`를 이용하여 문제를 해결하였습니다.
배열 `dp`는 3차원 배열로 앞의 두 인덱스는 좌표의 값 3번째 인덱스는 해당 좌표에 어떤 파이프로 도착하였나입니다.
저는 `0`을 가로 `1`을 세로 `2`를 대각선으로 생각하였습니다.
가장 먼저 맨 윗줄은 가로 파이프로만 도달 할 수 있기때문에 초기화를 진행해주었습니다.
그 다음 문제에서 요구한 파이프를 옮길 수 있는 조건을 확인하고 값을 구하였습니다.