### PR TITLE
[백준] 20437. 문자열 게임2 문제풀이

### DIFF
--- a/kim/src/BJ20437.java
+++ b/kim/src/BJ20437.java
@@ -1,0 +1,37 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class BJ20437 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(br.readLine());
+
+        while (T-- > 0) {
+            String w = br.readLine();
+            int k = Integer.parseInt(br.readLine());
+
+            Queue<Integer>[] qarr = new LinkedList[26]; // 짧은 길이를 구하기 위한 큐, 해당 알파벳이 나온 인덱스를 저장
+            for (int i = 0; i < 26; i++)
+                qarr[i] = new LinkedList<>();
+            int min = -1;
+            int max = -1;
+            boolean flag = false;
+
+            for (int i = 0; i < w.length(); i++) {
+                int c = w.charAt(i) - 'a';
+                qarr[c].offer(i);
+
+                if (qarr[c].size() >= k) {
+                    int len = i - qarr[c].poll() + 1;
+                    min = (min == -1) ? len : Math.min(min, len);
+                    max = Math.max(max, len);
+                    flag = true;
+                }
+            }
+            System.out.println((flag ? (min + " " + max) : -1));
+        }
+    }
+}


### PR DESCRIPTION
처음에는 문자열 길이만큼 `for`문을 돌리고 `boolean[] visit`배열을 이용해 해당 알파벳의 위치만 탐색해주려고 했습니다.
그런데 이러면 2중 `for`문을 사용할 수 밖에 없는데, 문자열의 길이가 `10,000` 까지이기 때문에 `O(N^2)`의 시간으로 해결할 수 없게 됩니다.

그래서 `Queue`를 이용하는 다른 방법으로 해결하였습니다.
문자열의 탐색을 진행하면서 해당 알파벳의 위치에 해당하는 큐 배열에 담아주었습니다.
`queue.size >= k`인 경우에만 구해야 하는 문자열의 길이를 갱신해주고, 문자열의 길이를 `k`로 유지해야 하기 때문에 원소 하나를 `poll()`해주었습니다.