### PR TITLE
[백준]1277. 발전소 설치 문제풀이

### DIFF
--- a/kim/src/BJ1277.java
+++ b/kim/src/BJ1277.java
@@ -66,7 +66,7 @@ public class BJ1277 {
     }
 
     private static double getDist(Point p1, Point p2) {
-        return Math.sqrt(Math.pow(Math.abs(p1.x - p2.x), 2) + Math.pow(Math.abs(p1.y - p2.y), 2));
+        return Math.sqrt(Math.pow(p1.x - p2.x, 2) + Math.pow(p1.y - p2.y, 2));
     }
 
     private static class Point {

--- a/kim/src/BJ1277.java
+++ b/kim/src/BJ1277.java
@@ -1,0 +1,84 @@
+import java.io.*;
+import java.util.*;
+
+public class BJ1277 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = parse(st.nextToken()); // 발전소의 수
+        int w = parse(st.nextToken()); // 현재 남아있는 전선의 수
+        double m = Double.parseDouble(br.readLine()); // 제한 길이
+
+        Point[] powerPlant = new Point[n + 1];
+
+        for (int i = 1; i <= n; i++) {
+            // 발전소의 좌표 등록하기
+            st = new StringTokenizer(br.readLine());
+            powerPlant[i] = new Point(parse(st.nextToken()), parse(st.nextToken()));
+        }
+
+        double[][] adj = new double[n + 1][n + 1]; // 발전소 간의 거리를 저장해줄 인접행렬
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= n; j++) {
+                adj[i][j] = getDist(powerPlant[i], powerPlant[j]);
+            }
+        }
+
+        for (int j = 0; j < w; j++) {
+            st = new StringTokenizer(br.readLine());
+            int from = parse(st.nextToken());
+            int to = parse(st.nextToken());
+
+            adj[from][to] = 0;
+            adj[to][from] = 0;
+        }
+
+        // 다익스트라 알고리즘을 통한 최단거리 찾기
+        double[] dist = new double[n + 1]; // 최소 비용을 저장할 배열
+        boolean[] visit = new boolean[n + 1]; // 방문제크
+        Arrays.fill(dist, Double.MAX_VALUE);
+        // 시작노드 설정
+        dist[1] = 0;
+
+        for (int i = 1; i <= n; i++) {
+            double min = Double.MAX_VALUE;
+            int minIdx = i;
+            for (int j = 1; j <= n; j++) {
+                if (!visit[j] && dist[j] < min) {
+                    min = dist[j];
+                    minIdx = j;
+                }
+            }
+
+            visit[minIdx] = true;
+            if (minIdx == n)
+                break;
+
+            for (int j = 1; j <= n; j++) {
+                if (!visit[j] && adj[minIdx][j] <= m && min + adj[minIdx][j] < dist[j]) {
+                    dist[j] = min + adj[minIdx][j];
+                }
+            }
+        }
+        System.out.println((int) (dist[n] * 1000));
+    }
+
+    private static double getDist(Point p1, Point p2) {
+        return Math.sqrt(Math.pow(Math.abs(p1.x - p2.x), 2) + Math.pow(Math.abs(p1.y - p2.y), 2));
+    }
+
+    private static class Point {
+        int x, y;
+
+        Point(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    private static int parse(String s) {
+        return Integer.parseInt(s);
+    }
+}


### PR DESCRIPTION
발전소 간의 거리를 인접행렬에 저장한 뒤에 다익스트라 알고리즘을 적용하여 풀 수 있었습니다.

길이 없는 경우에만 추가로 설치하면 되기 때문에 이미 경로가 있는 경우에는 인접행렬의 비용을 0으로 바꿔주었습니다.

`안정성 문제로 어떠한 두 발전소 사이의 전선의 길이가 M을 초과할 수는 없다` 조건을 위해서 `dist`배열 값을 갱신할 때 `adj[minIdx][j] <= m`조건을 넣어주었습니다.