### PR TITLE
[백준] 9944. NxM 보드 완주하기 문제풀이

### DIFF
--- a/minwoo.lee_java/src/BOJ9944.java
+++ b/minwoo.lee_java/src/BOJ9944.java
@@ -1,0 +1,91 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ9944 {
+    static int N, M, result, boardCnt;
+    static int[][] direction = {{0, 1}, {1, 0}, {0, -1}, {-1, 0}};
+    static char[][] map;
+    static boolean[][] discovered;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        StringTokenizer st;
+        String s;
+        int tc = 1;
+        while ((s = br.readLine()) != null) {
+            st = new StringTokenizer(s);
+            N = Integer.parseInt(st.nextToken());
+            M = Integer.parseInt(st.nextToken());
+            map = new char[N][M];
+            boardCnt = 0;
+            for (int i = 0; i < N; i++) {
+                String temp = br.readLine();
+                for (int j = 0; j < M; j++) {
+                    map[i][j] = temp.charAt(j);
+                    if (map[i][j] == '.') {
+                        boardCnt++;
+                    }
+                }
+            }
+            discovered = new boolean[N][M];
+            result = Integer.MAX_VALUE;
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < M; j++) {
+                    if (map[i][j] == '.') {
+                        discovered[i][j] = true;
+                        start(i, j, 1, 0);
+                        discovered[i][j] = false;
+                    }
+                }
+            }
+            if (result == Integer.MAX_VALUE) {
+                result = -1;
+            }
+            sb.append("Case " + tc++ + ": " + result + "\n");
+        }
+        System.out.print(sb);
+    }
+
+    private static void start(int startX, int startY, int step, int moveCnt) {
+        if (step == boardCnt) {
+            result = Math.min(result, moveCnt);
+            return;
+        }
+
+        for (int d = 0; d < 4; d++) {
+            int cnt = 0;
+            int x = startX;
+            int y = startY;
+            int nx, ny;
+            while (true) {
+                nx = x + direction[d][0];
+                ny = y + direction[d][1];
+                if (!check(nx, ny) || map[nx][ny] == '*' || discovered[nx][ny]) {
+                    break;
+                }
+                discovered[nx][ny] = true;
+                cnt++;
+                x = nx;
+                y = ny;
+            }
+            if (x == startX && y == startY) {
+                continue;
+            }
+            start(x, y, step + cnt, moveCnt + 1);
+            back(x, y, cnt, d);
+
+        }
+    }
+    private static void back(int x, int y, int cnt, int d) {
+        for (int i = 0; i < cnt; i++) {
+            discovered[x][y] = false;
+            x -= direction[d][0];
+            y -= direction[d][1];
+        }
+    }
+
+    private static boolean check(int nx, int ny) {
+        return (0 <= nx && nx < N && 0 <= ny && ny < M) ? true : false;
+    }
+}

--- a/minwoo.lee_java/src/BOJ9944.java
+++ b/minwoo.lee_java/src/BOJ9944.java
@@ -77,6 +77,7 @@ public class BOJ9944 {
 
         }
     }
+
     private static void back(int x, int y, int cnt, int d) {
         for (int i = 0; i < cnt; i++) {
             discovered[x][y] = false;
@@ -86,6 +87,6 @@ public class BOJ9944 {
     }
 
     private static boolean check(int nx, int ny) {
-        return (0 <= nx && nx < N && 0 <= ny && ny < M) ? true : false;
+        return 0 <= nx && nx < N && 0 <= ny && ny < M;
     }
 }


### PR DESCRIPTION
문제를 해결하는데 많은 시간이 걸렸는데 해결하였습니다.

먼저 주어진 입력에 대하여 이동해야할 칸을 `boardCnt`에 저장합니다.
시작 위치는 정해져있지 않으므로 모든 `.` 지점에서 탐색을 합니다.
현재 위치에서 4방향에 대하여 탐색을 진행합니다.
방향에 대하여 계속 그 방향으로 진행하는데 출발한 위치와 진행한 후 나중위치가
같다면 다음 재귀로 진행하지 않습니다.
재귀가 진행되면서 `boardCnt`와 `step`의 크기가 같아지면 모든 지점을 탐색한 것이므로
이동횟수를 기존의 값과 비교해서 작은 값으로 바꿔주고 `return`합니다.
재귀에서 빠져 나온후는 탐색한 곳을 다시 `discovered` 방문에 대한 배열을 `false`로 바꾸어줍니다.