### PR TITLE
[PG] 프로그래머스 신고 결과 받기 문제풀이

### DIFF
--- a/minwoo.lee_java/src/PG92334.java
+++ b/minwoo.lee_java/src/PG92334.java
@@ -1,0 +1,53 @@
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.StringTokenizer;
+
+public class PG92334 {
+    public static void main(String[] args) {
+    }
+
+    public int[] solution(String[] id_list, String[] report, int k) {
+        // 신고 결과 key : 신고를 당한사람 value : 신고를 한 사람들(중복X)
+        HashMap<String, HashSet<String>> reportResult = new HashMap<>();
+        StringTokenizer st;
+        for (int i = 0; i < report.length; i++) {
+            st = new StringTokenizer(report[i]);
+            // 신고를 한 사람
+            String from = st.nextToken();
+            // 신고를 당한 사람
+            String to = st.nextToken();
+            // 신고를 당한 사람에 대한 신고 결과 정보를 가져옴.
+            HashSet<String> setData = reportResult.getOrDefault(to, new HashSet<>());
+            setData.add(from);
+            reportResult.put(to, setData);
+        }
+
+        // key : 유저  value : 유저가 받을 결과 메일 수
+        HashMap<String, Integer> receiveCnt = new HashMap<>();
+        for (int i = 0; i < id_list.length; i++) {
+            receiveCnt.getOrDefault(id_list[i], 0);
+        }
+        for (String key : reportResult.keySet()) {
+            // 신고를 당한 사람에 대한 신고를 한 사람들 값을 가져옴
+            HashSet<String> value = reportResult.get(key);
+            // 신고를 한 사람들의 수가 k 이상이면 그 사람들에게 결과 메일이 감
+            if (value.size() >= k) {
+                Iterator<String> iter = value.iterator();
+                while (iter.hasNext()) {
+                    String name = iter.next();
+                    // 신고한 사람들은 결과 메일을 받으므로 cnt값을 증가시켜준다.
+                    int cnt = receiveCnt.getOrDefault(name, 0);
+                    cnt += 1;
+                    receiveCnt.put(name, cnt);
+                }
+            }
+        }
+
+        int[] result = new int[id_list.length];
+        for (int i = 0; i < id_list.length; i++) {
+            result[i] = receiveCnt.getOrDefault(id_list[i], 0);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
문제의 설명대로 기능을 구현하였습니다.
한 사람이 같은 사람을 여러번 신고 할 수 있지만 그 경우는 신고 횟수를 1회로 처리하기 때문에 중복을 제거해야 한다고 생각했습니다.
따라서 신고를 당한사람을 `Key`값, 신고를 한 사람들을 `Value`로 가지는 `HashMap`자료형의 `reportResult`를 만들어주었습니다. 
이 때 `Value`의 자료형은`HashSet`이 됩니다.

그리고 결과 메일을 받는 수를 관리하기 위해 신고를 한  사람을 `Key`값으로 가지고 받은 메일 수를 `Value`로 하는`HashMap` 자료형 `receiveCnt`를 하나 더 만들어주었습니다.

이 후 `report` 배열을 순회하며 신고 결과 값을 저장 후 각 유저들에 대해서 신고를 한 사람이 `K`명 이상인 경우 신고를 한 사람들의 `receiveCnt` `value` 값을 1씩 증가시켜주었습니다.