### PR TITLE
[백준] 1949. 우수 마을 문제풀이

### DIFF
--- a/minwoo.lee_java/src/BOJ1949.java
+++ b/minwoo.lee_java/src/BOJ1949.java
@@ -1,0 +1,50 @@
+import java.util.*;
+import java.io.*;
+
+public class BOJ1949 {
+    static int N;
+    static ArrayList<Integer>[] adjList;
+    static int[][] dp;
+    static int[] person;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        N = Integer.parseInt(br.readLine());
+        // dp[i][0] : i번째 마을이 우수마을이 아닌 경우, dp[i][1] : i번째 마을이 우수마을인 경우
+        dp = new int[N + 1][2];
+        // 마을의 인구정보를 담음
+        person = new int[N + 1];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            person[i] = Integer.parseInt(st.nextToken());
+        }
+
+        // 인접리스트 생성 : 마을간의 연결정보를 담음
+        adjList = new ArrayList[N + 1];
+        for (int i = 1; i <= N; i++) {
+            adjList[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < N - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int town1 = Integer.parseInt(st.nextToken());
+            int town2 = Integer.parseInt(st.nextToken());
+            adjList[town1].add(town2);
+            adjList[town2].add(town1);
+        }
+        bestTown(1, 0);
+        System.out.println(Math.max(dp[1][0], dp[1][1]));
+    }
+
+    private static void bestTown(int townNum, int parent) {
+        for (int child : adjList[townNum]) {
+            if (parent != child) {
+                bestTown(child, townNum);
+                dp[townNum][1] += dp[child][0];
+                dp[townNum][0] += Math.max(dp[child][0], dp[child][1]);
+            }
+        }
+        dp[townNum][1] += person[townNum];
+    }
+}


### PR DESCRIPTION
<p>트리와 <code>dp</code> 를 이용하여 해결하였습니다.</p>
<p>하나의 노드를 루트노드로 선택해 <code>재귀함수</code> 를 이용하여 리프노드까지 간 후 리프노드부터 <code>dp</code> 배열의 값을 구하였습니다.</p>
<ul>
<li><code>dp[n][0]</code> : <code>n</code>번 마을이 우수 마을이 아닐 때, <code>n</code>번 마을을 루트노드로 하는 하위트리의 마을 주민 수의 총합</li>
<li><code>dp[n][1]</code> : <code>n</code>번 마을이 우수 마을일 때, <code>n</code>번 마을을 루트노드로 하는 하위트리의 마을 주민 수의 총합</li>
</ul>
<p><code>n</code> 번 마을이 우수 마을이라면 자식 마을은 우수마을이 될 수 없습니다.</p>
<p><code>dp[townNum][1] += dp[child][0]</code></p>
<p><code>n</code>번 마을이 우수 마을이 아니라면 자식 마을은 우수 마을일 수도 있고 아닐 수도 있다.</p>
<p>1번 2번 3번 4번 마을이 있고 <code>1-2-3-4</code>  모양의 트리라 하였을 때 1번이 우수마을이 아닐 때 의 경우의 수는 다음과 같습니다.</p>


마을번호 | 1번 마을 | 2번 마을 | 3번 마을 | 4번 마을
-- | -- | -- | -- | --
경우의 수 1 | X | X | X | X
경우의 수 2 | X | X | X | O
경우의 수 3 | X | X | O | X
경우의 수 4 | X | O | X | X
경우의 수 5 | X | O | X | O

'우수 마을'로 선정된 마을 주민 수의 총 합을 최대로 해야 하므로 다음과 같은 점화식을 구할 수 있습니다.
<p><code>dp[townNum][0] += Math.max(dp[child][0], dp[child][1])</code></p>
