### PR TITLE
[백준]1949. 우수 마을 문제풀이

### DIFF
--- a/kim/src/BJ1949.java
+++ b/kim/src/BJ1949.java
@@ -1,0 +1,52 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class BJ1949 {
+
+    private static ArrayList<Integer>[] adj;
+    private static int[][] dp;
+    private static boolean[] visit;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = parse(br.readLine()); // 마을 수
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        adj = new ArrayList[n + 1];
+        visit = new boolean[n + 1];
+        dp = new int[n + 1][2];
+        for (int i = 1; i <= n; i++) {
+            dp[i][1] = parse(st.nextToken());
+            adj[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int v1 = parse(st.nextToken());
+            int v2 = parse(st.nextToken());
+            adj[v1].add(v2);
+            adj[v2].add(v1);
+        }
+
+        dfs(1);
+
+        System.out.println(Math.max(dp[1][0], dp[1][1]));
+    }
+
+    private static void dfs(int node) {
+        visit[node] = true;
+        for (int next : adj[node]) {
+            if (visit[next])
+                continue;
+            dfs(next);
+            dp[node][0] += Math.max(dp[next][0], dp[next][1]);
+            dp[node][1] += dp[next][0];
+        }
+    }
+
+    private static int parse(String s) {
+        return Integer.parseInt(s);
+    }
+}


### PR DESCRIPTION
문제에서 N개의 마을이 트리 구조로 이루어져 있다고 제시되기 때문에 어떤 입력이 주어지든 이 마을은 `1`을 루트 노드로 하는 트리의 형태로 나타낼 수 있습니다.

**풀이**
다이나믹 프로그래밍과 dfs를 이용하여 풀었습니다.
`int[][] dp`배열에서 `dp[i][0]`은 해당 마을이 우수마을이 아닐 때 누적될 수 있는 주민 수의 최대합이고
`dp[i][1]`은 해당 마을이 우수마을일 때의 주민 수의 최대합입니다.

해당 마을만 우수마을일 때의 주민 수는 주어지는 인원수 그대로일 것이기 때문에 맨 처음에 `dp[i][1]`에 초기값을 셋팅해줍니다.

그 다음에 맨 처음의 전제조건에 따라서 루트 노드인 1로부터 `dfs`를 타고 태려갑니다.

트리 구조라는것만 빼면 예전에 풀었던 [동물원](https://www.acmicpc.net/problem/1309)문제와 유사하게 생각하면 됩니다.

현재 마을 `node`가 우수마을인 경우는 `next`는 우수마을이면 안됩니다.
현재 마을 `node`가 우수마을이 아닌 경우 `next`는 우수마을이거나 우수마을이 아니거나 상관없습니다.

이렇게 연결된 모든 마을들의 최대 인원수들을 누적해서 더한 뒤에 `dp`배열에 저장하면 됩니다.

출력을 `dp[1]`에서만 비교해서 하는 이유는 자식 노드들의 최대 인구수합이 상위 노드로 저장되는데, 처음에 1을 루트 노드로 지정했기 때문에 최상단 노드인 1만 비교해주면 됩니다.
