### PR TITLE
[백준] 2056. 작업 문제풀이

### DIFF
--- a/minwoo.lee_java/src/BOJ2056.java
+++ b/minwoo.lee_java/src/BOJ2056.java
@@ -1,0 +1,61 @@
+import java.io.*;
+import java.util.*;
+
+public class BOJ2056 {
+    static int N;
+    static int[] inDegree, jobTime, endTime;
+    static ArrayList<Integer>[] nextJob;
+
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        init();
+        StringTokenizer st;
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int time = Integer.parseInt(st.nextToken());
+            jobTime[i] = time;
+            int prevCnt = Integer.parseInt(st.nextToken());
+            for (int j = 0; j < prevCnt; j++) {
+                int prev = Integer.parseInt(st.nextToken());
+                nextJob[prev].add(i);
+                inDegree[i]++;
+            }
+        }
+        topologySort();
+        System.out.println(Arrays.stream(endTime).max().getAsInt());
+
+    }
+
+    private static void topologySort() {
+        endTime = new int[N + 1];
+        Queue<Integer> queue = new LinkedList<>();
+        for (int i = 1; i <= N; i++) {
+            if (inDegree[i] == 0) {
+                queue.add(i);
+                endTime[i] = jobTime[i];
+            }
+        }
+
+        for (int i = 1; i <= N; i++) {
+            int num = queue.poll();
+            for (int idx = 0; idx < nextJob[num].size(); idx++) {
+                int next = nextJob[num].get(idx);
+                endTime[next] = Math.max(endTime[next], endTime[num] + jobTime[next]);
+                if (--inDegree[next] == 0) {
+                    queue.add(next);
+                }
+            }
+        }
+    }
+
+    private static void init() {
+        inDegree = new int[N + 1];
+        jobTime = new int[N + 1];
+        nextJob = new ArrayList[N + 1];
+        for (int i = 1; i <= N; i++) {
+            nextJob[i] = new ArrayList<>();
+        }
+    }
+}


### PR DESCRIPTION
각 작업별 `jobTime` 배열의 값을 저장해줍니다.
선행 관계에 있는 작업들의 수와 선행 관계 작업들이 주어질 때 
진입차수를 뜻하는 `inDegree`배열과 `nextJob` 값을 갱신해 줍니다.

이후 진입차수가 `0`인 작업들은 선행작업이 없다는 뜻이므로 `Queue`에 담아주며 이 작업들의 종료시간을 뜻하는 `endTime` 값을 `jobTime` 값으로 갱신해 줍니다.

`Queue`에서 값을 꺼내 다음 작업들에 대해서 `endTime` 값을 `endTime`값과 `endTime[num] + jobTime[next]` 값 중 큰 값으로 갱신해줍니다.
왜냐하면 다음작업의 종료시간은 선행 작업의 종료시간 중 제일 큰시간 값 + 해당 작업의 종료시간이기 때문입니다.

그리고 다음작업의 진입차수를 제거해주는데 이때 진입차수 값이 `0`이 되면 `Queue`에 담아줍니다.