### PR TITLE
[백준]20924. 트리의 기둥과 가지 문제풀이

### DIFF
--- a/kim/src/BJ20924.java
+++ b/kim/src/BJ20924.java
@@ -1,0 +1,81 @@
+import java.io.*;
+import java.util.*;
+
+public class BJ20924 {
+    private static int maxBranch, pole, giga;
+    private static boolean[] visit;
+    private static ArrayList<Node>[] adj;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = parse(st.nextToken());
+        int r = parse(st.nextToken());
+
+        visit = new boolean[n + 1];
+        adj = new ArrayList[n + 1];
+        for (int i = 0; i <= n; i++) {
+            adj[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = parse(st.nextToken());
+            int b = parse(st.nextToken());
+            int d = parse(st.nextToken());
+            adj[a].add(new Node(b, d));
+            adj[b].add(new Node(a, d));
+        }
+
+        visit[r] = true;
+        adj[r].add(new Node(0, 0));
+
+        getGiga(r, 0);
+        getBranch(giga, 0);
+        System.out.println(pole + " " + maxBranch);
+    }
+
+    private static void getGiga(int root, int dist) {
+        visit[root] = true;
+
+        if (adj[root].size() != 2 && root != 0) {
+            giga = root;
+            pole = dist;
+            return;
+        }
+        for (Node node : adj[root]) {
+            if (!visit[node.n]) {
+                getGiga(node.n, dist + node.d);
+            }
+        }
+    }
+
+    private static void getBranch(int root, int dist) {
+        visit[root] = true;
+
+        if (adj[root].size() == 1) {
+            maxBranch = Math.max(maxBranch, dist);
+            return;
+        }
+
+        for (Node node : adj[root]) {
+            if (!visit[node.n]) {
+                getBranch(node.n, dist + node.d);
+            }
+        }
+    }
+
+    private static class Node {
+        int n, d;
+
+        Node(int n, int d) {
+            this.n = n;
+            this.d = d;
+        }
+    }
+
+    private static int parse(String s) {
+        return Integer.parseInt(s);
+    }
+}


### PR DESCRIPTION
그래프 탐색과 `dfs`를 이용하여 풀 수 있는 문제였습니다.

우선 인접 리스트에 그래프의 연결 정보를 저장해줍니다.
그 후에 우리는 문제의 해답을 위해 기둥의 길이와 가장 긴 가지의 길이를 구해야 합니다.

1. 기둥의 길이
루트 노드로부터 기가 노드까지의 길이를 기둥의 길이라고 합니다.
기가 노드를 제외하면 기둥에 포함된 노드들은 이전 노드와 다음 노드의 두 개의 연결 정보밖에 가지고있지 않습니다. 이를 이용하여 `dfs`를 탐색하였습니다.
한 가지 주의할 점은 루트 노드인데, 루트 노드의 경우 연결된 노드가 다음 노드 한 개밖에 없습니다.
이를 위해서 범위에 존재하지 않는 `0`번 노드를 루트 노드에 달아준 뒤에 기가 노드 탐색에서 `root != 0`의 조건을 걸어서 일관성 있게 `dfs`로 검사해주었습니다.

2. 가장 긴 가지의 길이
기가 노드로부터 출발해서 현재 가지까지 길이를 `dist` 매개변수를 통해 전달해줍니다.
그 이후에 리프 노드에 도달하면 최댓값을 비교해주는데, 리프 노드의 경우 연결된 노드가 이전 노드 하나밖에 없다는 점을 이용하여 `(adj[root].size() == 1)` 조건에 도달했을 시 검사해주는 식으로 해결하였습니다.