### PR TITLE
[PG]67259. 경주로 건설 문제풀이

### DIFF
--- a/kim/src/PG67259.java
+++ b/kim/src/PG67259.java
@@ -1,0 +1,58 @@
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class PG67259 {
+    class Solution {
+        public int solution(int[][] board) {
+            int n = board.length;
+            final int[][] move = {{0,1}, {1,0},{0,-1},{-1,0}};
+            int[][][] dp = new int[n][n][4];
+            for(int i = 0; i < n; i++){
+                for(int j = 0; j < n; j++){
+                    for(int k = 0; k < 4; k++){
+                        dp[i][j][k] = Integer.MAX_VALUE;
+                    }
+                }
+            }
+
+            Queue<Car> q = new LinkedList<>();
+            dp[0][0][0] = 0;
+            dp[0][0][1] = 0;
+            q.offer(new Car(0, 0, 0));
+            q.offer(new Car(0, 0, 1));
+
+            while(!q.isEmpty()){
+                Car car = q.poll();
+
+                int[] tmp = {-1, 0, 1};
+                for(int d = 0; d < 3; d++){
+                    int nd = (car.dir + tmp[d] + 4) % 4;
+                    int ni = car.i + move[nd][0];
+                    int nj = car.j + move[nd][1];
+
+                    if(ni >= 0 && nj >= 0 && ni < n && nj < n && board[ni][nj] == 0){
+                        int cost = (d == 1) ? 100 : 600;
+                        if(dp[ni][nj][nd] > dp[car.i][car.j][car.dir] + cost){
+                            dp[ni][nj][nd] = dp[car.i][car.j][car.dir] + cost;
+                            q.offer(new Car(ni, nj, nd));
+                        }
+                    }
+                }
+            }
+            int min = dp[n-1][n-1][0];
+            for(int i = 1; i < 4; i++){
+                min = Math.min(min, dp[n-1][n-1][i]);
+            }
+            return min;
+        }
+    }
+
+    class Car{
+        int i, j, dir;
+        Car(int i, int j, int dir){
+            this.i=i;
+            this.j=j;
+            this.dir= dir;
+        }
+    }
+}


### PR DESCRIPTION
일단 차가 네 방향으로 움직일 수 있기 때문에
`final int[][] move = {{0,1}, {1,0},{0,-1},{-1,0}};` 배열을 만들고 시작합니다.
여기서 배열의 순서는 시계방향으로 설정해주었습니다.

그다음에 `int[][][] dp = new int[n][n][4];` 배열이 필요합니다.
3차원 배열로 한 이유는 차가 후진을 할 수 없기 때문에 해당 칸에 어떤 방향으로 도착하느냐에 따라서 결과가 달라질 수 있기 때문에 네 방향을 모두 고려해 준 것입니다.

그 다음에는 `bfs`를 수행해줍니다.
여기서 `int[] tmp = {-1, 0, 1};` 배열이 방향인데, `move`배열을 시계방향으로 설정해주었기 때문에 `move`배열의 인덱스를 현재 방향으로부터 좌회전, 직진, 우회전으로 설정해주기 위함입니다.
`bfs`를 수행하면서 직선도로인 경우 도로비용인 100원만, 꺾는 경우는 코너비용 500원을 더해 600원으로 설정해 `dp`배열을 갱신해줍니다.

마지막에 `dp[n-1][n-1]`에 있는 값들 중 가장 최저비용을 찾아주면 됩니다.