### PR TITLE
[백준] 16719. ZOAC 문제풀이

### DIFF
--- a/minwoo.lee_java/src/BOJ16719.java
+++ b/minwoo.lee_java/src/BOJ16719.java
@@ -1,0 +1,48 @@
+import java.io.*;
+
+public class BOJ16719 {
+    static char[] result;
+    static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String str = br.readLine();
+        result = new char[str.length()];
+        solution(str, 0, str.length());
+        System.out.print(sb);
+    }
+
+    private static void solution(String str, int from, int to) {
+        if (from == str.length() || from == to) {
+            return;
+        }
+        int idx = getMinIdx(str, from, to);
+        char minAlpha = str.charAt(idx);
+        result[idx] = minAlpha;
+        getStr();
+        solution(str, idx + 1, to);
+        solution(str, from, idx);
+    }
+
+    private static int getMinIdx(String str, int from, int to) {
+        int idx = from;
+        for (int i = idx + 1; i < to; i++) {
+            if (str.charAt(idx) > str.charAt(i)) {
+                idx = i;
+            }
+        }
+        return idx;
+    }
+
+    private static void getStr() {
+        for (int i = 0; i < result.length; i++) {
+            if (result[i] != '\u0000'){
+                sb.append(result[i]);
+            }
+        }
+        sb.append("\n");
+
+    }
+
+
+}


### PR DESCRIPTION
재귀를 이용하여 문제를 해결하였습니다.
문자열내의 알파벳에서 순서가 제일 빠른 알파벳의 인덱스를 구한후 `result`배열에 표시를 해주고 배열에 표시된 문자들의 합을 `StringBuilder`에 담아줍니다.
다음 재귀는 두 가지로 나누어 구하는데 1. 구한 인덱스 이후의 범위에서 2. 구한 인덱스 이전의 범위에서 가장 순서가 빠른 알파벳을 구하도록 하며 이를 반복합니다.
